### PR TITLE
fix: adjust pmbr size

### DIFF
--- a/gpt_image/table.py
+++ b/gpt_image/table.py
@@ -30,7 +30,9 @@ class ProtectiveMBR:
         self.partition_type = Entry(4, 1, b"\xEE")  # GPT partition type
         self.end_chs = Entry(5, 3, 0)  # ignore the end CHS
         self.start_sector = Entry(8, 4, geometry.primary_header_lba)
-        self.partition_size = Entry(12, 4, geometry.total_sectors)
+        # size, minus the protective MBR sector. This only works if the
+        # disk is under 2 TB
+        self.partition_size = Entry(12, 4, geometry.total_sectors - 1)
         self.signature = Entry(510, 4, b"\x55\xAA")
 
         self.mbr_fields = [

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -19,7 +19,7 @@ def test_protective_mbr_init(new_geometry):
     pmbr_bytes = pmbr.as_bytes()
     assert pmbr_bytes[4:5] == b"\xEE"
     assert pmbr_bytes[8:12] == geo.primary_header_lba.to_bytes(4, "little")
-    assert pmbr_bytes[12:16] == geo.total_sectors.to_bytes(4, "little")
+    assert pmbr_bytes[12:16] == (geo.total_sectors - 1).to_bytes(4, "little")
 
 
 def test_header_init_primary(new_geometry):


### PR DESCRIPTION
The protective MBR partition size was being set at the total sector size.  It should be one less that total, as the MBR itself is not counted.

Closes #12 