### PR TITLE
Refactor unpacking bytes to object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# project test files
+tests/testdata/*.raw
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/gpt_image/disk.py
+++ b/gpt_image/disk.py
@@ -84,7 +84,7 @@ class Disk:
             # zero entire disk
             f.write(b"\x00" * self.size)
             f.seek(0)
-            f.write(self.table.protective_mbr.as_bytes())
+            f.write(self.table.protective_mbr.byte_structure)
         self.write()
 
     def write(self):
@@ -98,19 +98,19 @@ class Disk:
         with open(self.image_path, "r+b") as f:
             # write primary header
             f.seek(self.geometry.primary_header_byte)
-            f.write(self.table.primary_header.as_bytes())
+            f.write(self.table.primary_header.byte_structure)
 
             # write primary partition table
             f.seek(self.geometry.primary_array_byte)
-            f.write(self.table.partitions.as_bytes())
+            f.write(self.table.partitions.byte_structure)
 
             # move to secondary header location and write
             f.seek(self.geometry.backup_header_byte)
-            f.write(self.table.secondary_header.as_bytes())
+            f.write(self.table.secondary_header.byte_structure)
 
             # write secondary partition table
             f.seek(self.geometry.backup_array_byte)
-            f.write(self.table.partitions.as_bytes())
+            f.write(self.table.partitions.byte_structure)
 
     def write_data(self, data: bytes, partition: Partition, offset: int = 0) -> None:
         # @NOTE: this isn't a GPT function. Writing data should be outside the

--- a/gpt_image/partition.py
+++ b/gpt_image/partition.py
@@ -57,7 +57,9 @@ class Partition:
         self.alignment = alignment
         self.size = size
 
-        self.partition_fields = [
+    @property
+    def byte_structure(self) -> bytes:
+        part_fields = [
             self.type_guid,
             self.partition_guid,
             self.first_lba,
@@ -65,10 +67,7 @@ class Partition:
             self.attribute_flags,
             self.partition_name,
         ]
-
-    def as_bytes(self) -> bytes:
-        """Return the partition as bytes"""
-        byte_list = [x.data_bytes for x in self.partition_fields]
+        byte_list = [x.data_bytes for x in part_fields]
         return b"".join(byte_list)
 
     def read(self, partition_bytes):
@@ -158,12 +157,10 @@ class PartitionEntryArray:
         f_lba = int(partition.first_lba.data)
         return (f_lba + lba) - 1
 
-    def as_bytes(self) -> bytes:
-        """Represent as bytes
-
-        Return the entire partition entry list as bytes
-        """
-        parts = [x.as_bytes() for x in self.entries]
+    @property
+    def byte_structure(self) -> bytes:
+        """Convert the Partition Array to its byte structure"""
+        parts = [x.byte_structure for x in self.entries]
         part_bytes = b"".join(parts)
         # pad the rest with zeros
         padded = part_bytes + b"\x00" * (

--- a/gpt_image/partition.py
+++ b/gpt_image/partition.py
@@ -1,6 +1,6 @@
 import uuid
 from math import ceil
-from typing import List
+from typing import List, Union
 
 from gpt_image.entry import Entry
 from gpt_image.geometry import Geometry
@@ -21,7 +21,7 @@ class Partition:
         self,
         name: str = "",
         size: int = 0,
-        partition_guid: uuid.UUID = "",
+        partition_guid: Union[None, uuid.UUID] = None,
         alignment: int = 8,
     ):
         """Initialize Partition Object

--- a/gpt_image/table.py
+++ b/gpt_image/table.py
@@ -31,8 +31,9 @@ class ProtectiveMBR:
         self._end_padding = Entry(462, 48, 0)  # padding before signature
         self.signature = Entry(510, 2, b"\x55\xAA")
 
-    def as_bytes(self) -> bytes:
-        """Get the Protective MBR as bytes"""
+    @property
+    def byte_structure(self) -> bytes:
+        """Convert Protective MBR to its byte structure"""
         pmbr_fields = [
             self._start_padding,
             self.boot_indicator,
@@ -123,8 +124,9 @@ class Header:
             self.header_start_byte = int(32 * self.geometry.sector_size)
             self.partition_entry_start_byte = 0
 
-    def as_bytes(self) -> bytes:
-        """Return the header as bytes"""
+    @property
+    def byte_structure(self) -> bytes:
+        """Convert the Header object to its byte structure"""
         header_fields = [
             self.header_sig,
             self.revision,
@@ -204,7 +206,7 @@ class Table:
         Args:
             header: initialized GPT header object
         """
-        part_entry_bytes = self.partitions.as_bytes()
+        part_entry_bytes = self.partitions.byte_structure
         header.partition_array_crc.data = binascii.crc32(part_entry_bytes)
 
     def checksum_header(self, header: Header) -> None:
@@ -218,4 +220,4 @@ class Table:
         """
         # zero the old checksum before calculating
         header.header_crc.data = 0
-        header.header_crc.data = binascii.crc32(header.as_bytes())
+        header.header_crc.data = binascii.crc32(header.byte_structure)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,7 +6,7 @@ from gpt_image.partition import Partition
 
 
 def test_e2e():
-    FILE_NAME = "test-disk.raw"
+    FILE_NAME = "tests/testdata/test-disk.raw"
     # cleanup old test file
     if os.path.isfile(FILE_NAME):
         os.remove(FILE_NAME)

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -41,7 +41,7 @@ def test_add():
 
 def test_unmarshal():
     part = Partition(PART_NAME, 4 * 1024)
-    part_b = part.as_bytes()
+    part_b = part.byte_structure
 
     part2 = Partition()
     part2.read(part_b)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -15,8 +15,8 @@ def new_geometry():
 def test_protective_mbr_init(new_geometry):
     geo = new_geometry
     pmbr = ProtectiveMBR(geo)
-    assert type(pmbr.as_bytes()) == bytes
-    pmbr_bytes = pmbr.as_bytes()
+    assert type(pmbr.byte_structure) == bytes
+    pmbr_bytes = pmbr.byte_structure
     assert pmbr_bytes[pmbr.partition_type.offset : pmbr.partition_type.end] == b"\xEE"
     assert pmbr_bytes[
         pmbr.start_sector.offset : pmbr.start_sector.end
@@ -30,7 +30,7 @@ def test_proctective_mbr_read(new_geometry):
     pmbr = ProtectiveMBR(new_geometry)
     # change partition type to test it's read back properly
     pmbr.partition_type.data = b"\xFF"
-    pmbr_b = pmbr.as_bytes()
+    pmbr_b = pmbr.byte_structure
     new_pmbr = ProtectiveMBR(new_geometry)
     new_pmbr.read(pmbr_b)
     assert new_pmbr.partition_type.data == b"\xFF"
@@ -58,7 +58,7 @@ def test_header_init_backup(new_geometry):
 
 def test_header_read(new_geometry):
     head = Header(new_geometry, uuid.uuid4())
-    head_b = head.as_bytes()
+    head_b = head.byte_structure
 
     head_ex = Header(new_geometry)
     head_ex.read(head_b)


### PR DESCRIPTION
Uses a Python property to unpack bytes to objects.  This cleans up the previous `as_bytes` function and uses an object attribute.

Fixes a type error on the partition object.

Ignores test images to allow external tests