### PR TITLE
Fix partition commit offset calculation

### DIFF
--- a/gpt_image/partition.py
+++ b/gpt_image/partition.py
@@ -277,8 +277,8 @@ class Partition:
                 data = self.read(disk, max_size=chunk_size, offset=count)
                 if not data:
                     break
-                count += len(data)
                 self._write_data(f, start + count, bytes(data))
+                count += len(data)
         finally:
             if tmpfile is None:
                 f.close()


### PR DESCRIPTION
Implement the fix mentioned in https://github.com/swysocki/gpt-image/issues/55.

TLDR: The offset calculation is wrong in the partition committing code, which results in corrupt disk images.